### PR TITLE
Prevent User Enumeration using wp-json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+services:
+- docker
+language: python
+python:
+  - 2.7
+before_install:
+  - |
+    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+      cd test/ && docker build --build-arg COMMIT=$TRAVIS_PULL_REQUEST_SHA -f Dockerfile . -t wprs/modsecurity
+    else
+      cd test/ && docker build --build-arg COMMIT=master -f Dockerfile . -t wprs/modsecurity
+    fi
+  - docker run -d --name wprs -p 80:80 wprs/modsecurity:latest
+script:
+  - TEST=$(curl -sI 'http://localhost/' | head -1 | egrep '200 OK' | wc -l) && if [ $TEST -eq 1 ]; then echo "OK - TEST /"; else exit 1; fi
+  - TEST=$(curl -sI 'http://localhost/?author=1' | head -1 | egrep '403 Forbidden' | wc -l) && if [ $TEST -eq 1 ]; then echo "OK - TEST User Enumeration"; else exit 1; fi
+  - docker stop wprs
+  - docker rm -f wprs 
+

--- a/02-INITIALIZATION.conf
+++ b/02-INITIALIZATION.conf
@@ -60,4 +60,4 @@ SecAction \
    nolog,\
    pass,\
    t:none,\
-   setvar:'tx.wprs_version=WPRS/1.0'"
+   setvar:'tx.wprs_version=WPRS/1.1'"

--- a/05-HARDENING.conf
+++ b/05-HARDENING.conf
@@ -63,7 +63,22 @@ SecRule tx:wprs_allow_user_enumeration "@eq 1" \
 
 SecMarker BEGIN_WPRS_USER_ENUMERATION
 
-SecRule REQUEST_URI "(author\=[0-9]+)" "phase:1,id:22200019,\
+SecRule REQUEST_URI "(author\=[0-9]+)" "phase:1,id:22200029,\
+  t:lowercase,t:urlDecode,t:trim,\
+  block,\
+  log,\
+  rev:'1',\
+  severity:'6',\
+  maturity:'9',\
+  accuracy:'9',\
+  capture,\
+  ver:'%{tx.wprs_version}',\
+  tag:'wordpress',\
+  tag:'enumeration',\
+  logdata:'Detected on %{TX:1}',\
+  msg:'WordPress: User enumeration'"
+
+SecRule REQUEST_FILENAME "^(/wp\-json/wp/v[0-9]+/users)" "phase:1,id:22200033,\
   t:lowercase,t:urlDecode,t:trim,\
   block,\
   log,\

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,29 @@
+FROM owasp/modsecurity:v3-ubuntu-nginx
+MAINTAINER Andrea Menin (theMiddle)
+
+ENV PARANOIA=1
+
+#RUN dnf -y update
+
+#RUN dnf -y install python
+
+RUN apt-get update && apt-get install -y \
+	git \
+	python
+
+RUN mv /etc/nginx/modsecurity.d/modsecurity.conf /etc/nginx/modsecurity.d/modsecurity.conf.old && \
+  cd /opt && \
+  git clone https://github.com/Rev3rseSecurity/wordpress-modsecurity-ruleset.git && \
+  cd wordpress-modsecurity-ruleset && git checkout $COMMIT && \
+  echo 'SecAction "id:22000025,phase:1,nolog,pass,t:none,setvar:tx.wprs_allow_xmlrpc=0"' >> /etc/nginx/modsecurity.d/include.conf && \
+  echo 'SecAction "id:22000030,phase:1,nolog,pass,t:none,setvar:tx.wprs_allow_user_enumeration=0"' >> /etc/nginx/modsecurity.d/include.conf && \
+  echo 'Include /opt/wordpress-modsecurity-ruleset/*.conf' >> /etc/nginx/modsecurity.d/include.conf
+
+COPY modsecurity.conf /etc/nginx/modsecurity.d/
+COPY crs-setup.conf /etc/nginx/modsecurity.d/
+
+EXPOSE 80
+
+#ENTRYPOINT ["/docker-entrypoint.sh"]
+#CMD ["httpd", "-k", "start", "-D", "FOREGROUND"]
+CMD ["/usr/local/nginx/nginx", "-g", "daemon off;"]

--- a/test/crs-setup.conf
+++ b/test/crs-setup.conf
@@ -1,0 +1,37 @@
+SecDefaultAction "phase:1,log,auditlog,deny,status:403"
+SecDefaultAction "phase:2,log,auditlog,deny,status:403"
+
+SecCollectionTimeout 600
+
+SecAction \
+ "id:900130,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  setvar:tx.crs_exclusions_wordpress=1"
+
+SecAction \
+  "id:900000,\
+   phase:1,\
+   nolog,\
+   pass,\
+   t:none,\
+   setvar:tx.paranoia_level=1"
+
+SecAction \
+  "id:900001,\
+   phase:1,\
+   nolog,\
+   pass,\
+   t:none,\
+   setvar:tx.executing_paranoia_level=1"
+
+SecAction \
+ "id:900990,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  setvar:tx.crs_setup_version=302"
+

--- a/test/modsecurity.conf
+++ b/test/modsecurity.conf
@@ -1,0 +1,59 @@
+SecRuleEngine On
+SecRequestBodyAccess On
+
+SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
+     "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
+
+SecRule REQUEST_HEADERS:Content-Type "application/json" \
+     "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
+
+SecRequestBodyLimit 13107200
+SecRequestBodyNoFilesLimit 131072
+SecRequestBodyLimitAction Reject
+
+SecRule REQBODY_ERROR "!@eq 0" \
+"id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"
+
+SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
+"id:'200003',phase:2,t:none,log,deny,status:400, \
+msg:'Multipart request body failed strict validation: \
+PE %{REQBODY_PROCESSOR_ERROR}, \
+BQ %{MULTIPART_BOUNDARY_QUOTED}, \
+BW %{MULTIPART_BOUNDARY_WHITESPACE}, \
+DB %{MULTIPART_DATA_BEFORE}, \
+DA %{MULTIPART_DATA_AFTER}, \
+HF %{MULTIPART_HEADER_FOLDING}, \
+LF %{MULTIPART_LF_LINE}, \
+SM %{MULTIPART_MISSING_SEMICOLON}, \
+IQ %{MULTIPART_INVALID_QUOTING}, \
+IP %{MULTIPART_INVALID_PART}, \
+IH %{MULTIPART_INVALID_HEADER_FOLDING}, \
+FL %{MULTIPART_FILE_LIMIT_EXCEEDED}'"
+
+SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
+"id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
+
+SecPcreMatchLimit 1000
+SecPcreMatchLimitRecursion 1000
+
+SecRule TX:/^MSC_/ "!@streq 0" \
+        "id:'200005',phase:2,t:none,deny,msg:'ModSecurity internal error flagged: %{MATCHED_VAR_NAME}'"
+
+SecResponseBodyAccess On
+SecResponseBodyMimeType text/plain text/html text/xml
+SecResponseBodyLimit 524288
+SecResponseBodyLimitAction ProcessPartial
+SecTmpDir /tmp/
+SecDataDir /tmp/
+SecAuditEngine On
+SecAuditLogParts ABIJDEFHZ
+SecAuditLogType Concurrent
+SecAuditLogFormat JSON
+SecDebugLog /var/log/modsec-debug.log
+SecDebugLogLevel 9
+
+SecArgumentSeparator &
+SecCookieFormat 0
+SecUnicodeMapFile unicode.mapping 20127
+SecStatusEngine On
+Include /etc/nginx/modsecurity.d/crs-setup.conf


### PR DESCRIPTION
This PR add rule `22200033` in order to prevent user enumeration by requesting `/wp-json/wp/v*/users`. By setting `wprs_allow_user_enumeration` to 0, all requests to `/wp-json/wp/v[0-9]+/users` will be blocked.