### PR TITLE
Add wprs_check_bruteforce on phase 2,3 / Add Login Failed logging rule

### DIFF
--- a/03-BRUTEFORCE.conf
+++ b/03-BRUTEFORCE.conf
@@ -9,6 +9,20 @@ SecRule tx:wprs_check_bruteforce "@eq 0" \
   nolog,\
   skipAfter:END_WPRS_BRUTEFORCE"
 
+SecRule tx:wprs_check_bruteforce "@eq 0" \
+  "phase:2,\
+  id:22100002,\
+  pass,\
+  nolog,\
+  skipAfter:END_WPRS_BRUTEFORCE"
+
+SecRule tx:wprs_check_bruteforce "@eq 0" \
+  "phase:3,\
+  id:22100003,\
+  pass,\
+  nolog,\
+  skipAfter:END_WPRS_BRUTEFORCE"
+
 SecMarker BEGIN_WPRS_BRUTEFORCE
 
 SecAction "phase:1,id:22100011,nolog,pass,initcol:ip=%{tx.wprs_client_ip}"

--- a/04-EVENTS.conf
+++ b/04-EVENTS.conf
@@ -40,4 +40,22 @@ SecRule RESPONSE_STATUS "@eq 302" "phase:3,id:22110013,nolog,chain,pass"
         tag:'logout',\
         msg:'WordPress: User logged out'"
 
+SecRule &RESPONSE_HEADERS:Set-Cookie "@eq 1" "phase:3,id:22110014,nolog,chain,pass"
+  SecRule &RESPONSE_HEADERS:Location "@eq 0" "id:22110014,nolog,chain"
+    SecRule REQUEST_METHOD "^POST$" "id:22110014,t:uppercase,nolog,chain"
+      SecRule &ARGS_POST_NAMES:log "@ge 1" "id:22110014,t:lowercase,nolog,chain"
+        SecRule &ARGS_POST_NAMES:pwd "@ge 1" "id:22110014,t:lowercase,nolog,chain"
+          SecRule REQUEST_FILENAME "^/wp\-login\.php" "id:22110014,t:lowercase,\
+            log,\
+            rev:'1',\
+            severity:'6',\
+            maturity:'9',\
+            accuracy:'9',\
+            ver:'%{tx.wprs_version}',\
+            tag:'wordpress',\
+            tag:'login',\
+            tag:'failed',\
+            logdata:'Login failed with username: %{ARGS_POST:log}',\
+            msg:'WordPress: Login failed'"
+
 SecMarker END_WPRS_LOG_AUTH


### PR DESCRIPTION
This PR fixes the checking of `wprs_check_bruteforce` variable (in order to enable or disable the brute-force mitigation function) by adding it on `phase:2` and `phase:3`, and add a new "event logging rule" in order to intercept all Login Failed on `wp-login.php`.