### PR TITLE
DoS protection and new rule 22200039 for CVE-2018-6389

### DIFF
--- a/01-SETUP.conf
+++ b/01-SETUP.conf
@@ -101,3 +101,15 @@
 # default: 1
 #
 #SecAction "id:22000030,phase:1,nolog,pass,t:none,setvar:tx.wprs_allow_user_enumeration=1"
+
+
+# -=[ Rule 22000035: DoS Attack ]=-
+# This rule enable or disable protection against DoS attacks.
+# For example prevent CVE-2018-6389.
+#
+# setvar:tx.wprs_check_dos=1 = enable DoS protection
+# setvar:tx.wprs_check_dos=0 = disable DoS protection
+#
+# default: 1
+#
+#SecAction "id:22000035,phase:1,nolog,pass,t:none,setvar:tx.wprs_check_dos=1"

--- a/02-INITIALIZATION.conf
+++ b/02-INITIALIZATION.conf
@@ -54,6 +54,13 @@ SecRule &tx:wprs_allow_user_enumeration "@eq 0" \
   nolog,\
   setvar:tx.wprs_allow_user_enumeration=1"
 
+SecRule &tx:wprs_check_dos "@eq 0" \
+  "phase:1,\
+  id:22000108,\
+  pass,\
+  nolog,\
+  setvar:tx.wprs_check_dos=1"
+
 SecAction \
   "id:22000199,\
    phase:1,\

--- a/05-HARDENING.conf
+++ b/05-HARDENING.conf
@@ -94,3 +94,30 @@ SecRule REQUEST_FILENAME "^(/wp\-json/wp/v[0-9]+/users)" "phase:1,id:22200033,\
   msg:'WordPress: User enumeration'"
 
 SecMarker END_WPRS_USER_ENUMERATION
+
+SecRule tx:wprs_check_dos "@eq 0" \
+  "phase:1,\
+  id:22200036,\
+  pass,\
+  nolog,\
+  skipAfter:END_WPRS_DOS"
+
+SecMarker BEGIN_WPRS_DOS
+
+SecRule REQUEST_URI "@rx ^/wp\-admin/(load\-styles|load\-scripts)\.php.*load\[\]\=([^&,]*,){20,}" "phase:1,id:22200039,\
+  t:lowercase,t:urlDecode,t:trim,t:normalizePath,t:removeWhitespace,\
+  block,\
+  log,\
+  rev:'1',\
+  severity:'6',\
+  maturity:'9',\
+  accuracy:'9',\
+  capture,\
+  ver:'%{tx.wprs_version}',\
+  tag:'wordpress',\
+  tag:'dos',\
+  tag:'cve-2018-6389',\
+  logdata:'Detected on script: %{TX:1}.php',\
+  msg:'WordPress: DoS Attack Attempt'"
+
+SecMarker END_WPRS_DOS


### PR DESCRIPTION
This PR adds a DoS Protection section and a new rule (22200039) in order to mitigate the CVE-2018-6389. I've taken the idea from @rastating blog here: https://rastating.github.io/protecting-wordpress-against-cve-2018-6389/